### PR TITLE
Support concurrent, multi-process access to cedict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /package-lock.json
 /node_modules
 cedict_db
+.idea/

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ const decode = require('cedict/decode')
 const hsk = require('cedict/hsk')
 const fetch = require('node-fetch')
 const sublevel = require('sublevel')
-const { promisify } = require('util')
-const level = promisify(require('level'))
+const level = require('level-party')
 const get = require('./lib/get')
 
 let state = {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "cedict": "^1.12.0",
     "level": "^4.0.0",
+    "level-party": "^4.0.0",
     "node-fetch": "^2.3.0",
     "pinyin-split": "^1.27.0",
     "pinyin-utils": "^1.14.0",


### PR DESCRIPTION
Thanks @pepebecker for a great plugin. This patch fixes a critical edge case.

Problem:
mdbg loads cedict via the npm package `level`, which creates a local single-process file lock. When multiple processes try to access (e.g. on a node server using multiple await statements, which may spawn multiple processes to invoke mdbg functions), an exception is thrown and the mdbg functions completely fail.

Solution: 
Replace level with level-party, a wrapper around level that enables concurrent access. See: https://www.npmjs.com/package/level-party

Tests pass, and this was tested in production and resolves the above problem.

Sidenote:
It would be useful to move away from relying on node filesystem + level, in order to support use cases on the client-side that do not have local file system IO access (e.g. react applications or chrome extension)